### PR TITLE
Add a config option to force doing trigrams even for digit words

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .cache
 __pycache__
 *.egg-info
+.pytest_cache
+dist/
+build/

--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ In your local configuration file:
         INDEXERS_PYPATHS.remove('addok.pairs.PairsIndexer')
         INDEXERS_PYPATHS.remove('addok.autocomplete.EdgeNgramIndexer')
 
+By default, digit only words are not turned into trigrams. To prevent this,
+set `TRIGRAM_SKIP_DIGIT=False`.
+
 
 ## Usage
 

--- a/addok_trigrams/__init__.py
+++ b/addok_trigrams/__init__.py
@@ -1,4 +1,5 @@
 from addok import hooks
+from addok.config import config
 
 
 def housenumber_field_key(s):
@@ -6,7 +7,7 @@ def housenumber_field_key(s):
 
 
 def compute_trigrams(token):
-    if token.isdigit():
+    if config.TRIGRAM_SKIP_DIGIT and token.isdigit():
         return [token]
     max = len(token)
     if max < 3:
@@ -73,6 +74,7 @@ def preconfigure(config):
     hooks.block('addok.pairs')
     hooks.block('addok.fuzzy')
     hooks.block('addok.autocomplete')
+    config.TRIGRAM_SKIP_DIGIT = True
 
 
 def configure(config):


### PR DESCRIPTION
In an ideal world, this would be a per field configuration (through `FIELDS`), but it's not that simple: once indexed, at search time, when doing the normal autocomplete (not the trigram based one), we've lost the information.

So let's proceed this simple way for now.

I need it for [addok-idcc](https://github.com/addok/addok-idcc), we want to autocomplete even the codes.